### PR TITLE
simfetch: Robustify memory_display fetching

### DIFF
--- a/simfetch
+++ b/simfetch
@@ -89,7 +89,7 @@ get_info() {
     else
         packages_info="Unknown"
     fi
-    memory_display=$(free -m | awk 'NR==2{printf "%.1f / %.1f GB (%d%%)", $s3/1024, $2/1024, $3*100/$2}')
+    memory_display=$(free -m | awk '/^Mem:/ {printf "%.1f / %.1f GB (%d%%)\n", $3/1024, $2/1024, $3*100/$2}')
 }
 
 # --- FUNCTION: Display ASCII Tux ---


### PR DESCRIPTION
Fetch "Mem" instead of row. And also fix column fetching.

free -m
               total        used        free      shared  buff/cache   available
Mem:           23925        5362       16701         517        3553       18562
Swap:          23924           0       23924

before:
0.0 / 23.4 GB (22%)
after:
5.2 / 23.4 GB (22%)